### PR TITLE
feat: :sparkles: implement the HttpHandler

### DIFF
--- a/health_check.go
+++ b/health_check.go
@@ -11,6 +11,7 @@ import (
 
 type Client interface {
 	Handler(ctx context.Context, healthchecks ...HealthChecker) func(echo.Context) error
+	HttpHandler(ctx context.Context, tests ...Test) func(echo.Context) error
 }
 
 type HealthCheckLogger interface {

--- a/http_handler.go
+++ b/http_handler.go
@@ -1,0 +1,17 @@
+package healthcheck
+
+import (
+	"context"
+
+	"github.com/labstack/echo/v4"
+)
+
+func (cli *client) HttpHandler(ctx context.Context, tests ...Test) func(echo.Context) error {
+	return func(c echo.Context) error {
+		err := laboratory(ctx, cli.logger, tests...)
+		if err != nil {
+			return echo.NewHTTPError(cli.failureStatusCode, err)
+		}
+		return err
+	}
+}

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -1,0 +1,84 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_client_HttpHandler(t *testing.T) {
+	e := echo.New()
+	t.Run("when the context is already cancelled, we should return that error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		cli := NewClient("tst")
+
+		err := cli.HttpHandler(ctx, Test{name: "test", method: func(ctx context.Context) error { return nil }})(c)
+		assert.ErrorContains(t, err, context.Canceled.Error())
+		assert.Equal(t, 503, getStatusCode(rec, err))
+	})
+
+	t.Run("when a test errors, we should return that error", func(t *testing.T) {
+		ctx := context.TODO()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		cli := NewClient("tst")
+		expect := errors.New("some error")
+
+		et := Test{
+			name: "errors",
+			method: func(ctx context.Context) error {
+				return expect
+			},
+		}
+
+		err := cli.HttpHandler(ctx, et)(c)
+		assert.ErrorContains(t, err, expect.Error())
+		assert.Equal(t, 503, getStatusCode(rec, err))
+	})
+
+	t.Run("when no tests error, we should return a 200", func(t *testing.T) {
+		ctx := context.TODO()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+
+		cli := NewClient("tst")
+
+		err := cli.HttpHandler(
+			ctx,
+			Test{name: "t1", method: func(ctx context.Context) error { return nil }},
+			Test{name: "t2", method: func(ctx context.Context) error { return nil }},
+			Test{name: "t3", method: func(ctx context.Context) error { return nil }},
+		)(c)
+
+		assert.NoError(t, err)
+		assert.Equal(t, 200, getStatusCode(rec, err))
+	})
+}
+
+func getStatusCode(rec *httptest.ResponseRecorder, err error) int {
+	ec := 500
+	if err == nil {
+		return rec.Code
+	}
+
+	httperr := &echo.HTTPError{}
+	if errors.As(err, &httperr) {
+		ec = httperr.Code
+	}
+
+	return ec
+}


### PR DESCRIPTION
this wraps the laboratory and provides an echo handler

by implementing this way, we leave the module open to other types of connection (ie gRPC)